### PR TITLE
Update workflow to chunk HTML before Notion

### DIFF
--- a/BENTLEY_V4.json
+++ b/BENTLEY_V4.json
@@ -632,9 +632,8 @@
         "blockUi": {
           "blockValues": [
             {
-              "textContent": "={{ $json.html }}"
-            },
-            {}
+              "textContent": "={{ $json.textContent }}"
+            }
           ]
         },
         "options": {}
@@ -653,6 +652,19 @@
           "name": "Notion account"
         }
       }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Split HTML into 2000 character chunks\nconst html = $json.html || '';\nconst chunkSize = 2000;\nconst itemsOut = [];\nfor (let i = 0; i < html.length; i += chunkSize) {\n  itemsOut.push({ json: { textContent: html.slice(i, i + chunkSize) } });\n}\nreturn itemsOut;"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1910,
+        -300
+      ],
+      "id": "3cf8354d-38cb-4669-a99c-d43816e9e980",
+      "name": "Split HTML"
     }
   ],
   "pinData": {},
@@ -932,6 +944,17 @@
       ]
     },
     "HTML1": {
+      "main": [
+        [
+          {
+            "node": "Split HTML",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Split HTML": {
       "main": [
         [
           {


### PR DESCRIPTION
## Summary
- insert a code node to split the HTML into 2000 character chunks
- feed these chunks to the Notion node via new connections
- update the Notion block to read from `textContent`

## Testing
- `jq empty BENTLEY_V4.json`

------
https://chatgpt.com/codex/tasks/task_e_683ad3e0aff0832c853d4364127bbdc8